### PR TITLE
[fix] `split_range`の実行中にパラメータが変化したとき、処理を中断して新しく処理を開始するよう修正

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use tauri::{api::dialog::blocking::FileDialogBuilder, State};
 
-use crate::EditorState;
+use crate::{EditorState, SplitRangeCount};
 
 #[tauri::command]
 pub fn select_file() -> Option<PathBuf> {
@@ -35,11 +35,18 @@ pub async fn samples_extraction(
 #[tauri::command]
 pub async fn split_range(
     state: State<'_, EditorState>,
+    count: State<'_, SplitRangeCount>,
     threshold: i32,
     talk_dur_sec: f32,
     mute_dur_sec: f32,
     extend_sec: f32
 ) -> Result<Vec<Vec<usize>>, ()> {
     let audio_editor = state.0.lock().unwrap().clone();
-    Ok(audio_editor.split_range(threshold, talk_dur_sec, mute_dur_sec, extend_sec))
+    let count = count.0.clone();
+    
+    *count.lock().unwrap() += 1;
+
+    let result = audio_editor.split_range(count.clone(), threshold, talk_dur_sec, mute_dur_sec, extend_sec);
+
+    result.ok_or(())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,7 +6,7 @@
 mod commands;
 mod audio;
 
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use audio::AudioEditor;
 use tauri::{
@@ -19,6 +19,7 @@ use tauri::{
 use crate::commands::*;
 
 pub struct EditorState(Mutex<AudioEditor>);
+pub struct SplitRangeCount(Arc<Mutex<i32>>);
 
 fn main() {
     let open_file = CustomMenuItem::new("open_file".to_owned(), "Open File...");
@@ -34,6 +35,7 @@ fn main() {
 
     tauri::Builder::default()
         .manage(EditorState(Default::default()))
+        .manage(SplitRangeCount(Arc::new(Mutex::new(0))))
         .setup(|app| {
             #[cfg(debug_assertions)]
             app.get_window("main").unwrap().open_devtools();


### PR DESCRIPTION
tauriが管理する状態に`SplitRangeCount(Arc<Mutex<i32>>)`を追加した。

commands.rsで`split_range`が呼び出される度にこの値が増加し、これをaudio.rsの`split_range`に渡す。
audio.rsの`split_range`ではこの渡された値を保持しておき、forループ内で`SplitRangeCount`の現在の値と比較して異なる値だった場合は新しいパラメータで再び呼び出されているから、現在の処理を中断し即座に`None`を返すようにした。